### PR TITLE
Fix NoSuchMethodError with DiscordSRV hook

### DIFF
--- a/src/main/java/com/cnaude/purpleirc/GameListeners/DiscordListener.java
+++ b/src/main/java/com/cnaude/purpleirc/GameListeners/DiscordListener.java
@@ -44,7 +44,7 @@ public class DiscordListener {
     @Subscribe(priority = ListenerPriority.MONITOR)
     public void onDiscordGuildMessageReceivedEvent(DiscordGuildMessageReceivedEvent event) {
         if (discordPlugin.getConfig().getBoolean("DiscordChatChannelListCommandEnabled")
-                && event.getMessage().getContent().equalsIgnoreCase(discordPlugin.getConfig().getString("DiscordChatChannelListCommandMessage"))) {
+                && event.getMessage().getContentRaw().equalsIgnoreCase(discordPlugin.getConfig().getString("DiscordChatChannelListCommandMessage"))) {
             plugin.logDebug("[onDiscordGuildMessageReceivedEvent] Ignoring DiscordChatChannelListCommandMessage");
             return;
         }
@@ -54,7 +54,7 @@ public class DiscordListener {
                     event.getMember().getEffectiveName(),
                     event.getMember().getColor(),
                     event.getChannel().getName(),
-                    event.getMessage().getContent());
+                    event.getMessage().getContentDisplay());
         }
 
     }


### PR DESCRIPTION
Caused by: java.lang.NoSuchMethodError: github.scarsz.discordsrv.dependencies.jda.core.entities.Message.getContent()Ljava/lang/String;