### PR TITLE
Don't attempt to send empty messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target/
 /nbactions.xml
-/dependency-reduced-pom
+/dependency-reduced-pom.xml
+
+/.idea/
+/*.iml

--- a/src/main/java/com/cnaude/purpleirc/IRCMessageQueueWatcher.java
+++ b/src/main/java/com/cnaude/purpleirc/IRCMessageQueueWatcher.java
@@ -80,7 +80,7 @@ public class IRCMessageQueueWatcher {
     }
 
     private void blockingIRCMessage(final String target, final String message) {
-        if (!ircBot.isConnected()) {
+        if (!ircBot.isConnected() || message.isEmpty()) {
             return;
         }
         plugin.logDebug("[blockingIRCMessage] About to send IRC message to " + target + ": " + message);
@@ -89,7 +89,7 @@ public class IRCMessageQueueWatcher {
     }
 
     private void blockingCTCPMessage(final String target, final String message) {
-        if (!ircBot.isConnected()) {
+        if (!ircBot.isConnected() || message.isEmpty()) {
             return;
         }
         plugin.logDebug("[blockingCTCPMessage] About to send IRC message to " + target + ": " + message);
@@ -98,7 +98,7 @@ public class IRCMessageQueueWatcher {
     }
 
     private void blockingNoticeMessage(final String target, final String message) {
-        if (!ircBot.isConnected()) {
+        if (!ircBot.isConnected() || message.isEmpty()) {
             return;
         }
         plugin.logDebug("[blockingNoticeMessage] About to send IRC notice to " + target + ": " + message);


### PR DESCRIPTION
This prevents seeing an error message like this every time the bot attempts to send empty messages to IRC:
`[PurpleIRC] :kornbluth.freenode.net 412 MCAU :No text to send`
Empty messages are caused by having a silent join/quit plugin.