### PR TITLE
Add RGB text display for Spigot servers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
     </pluginRepositories>
 
     <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+
         <!-- For anything else without its own repo -->
         <repository>
             <id>cnaude-repo</id>
@@ -70,7 +75,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-
     </repositories>
   
     <dependencies>
@@ -146,7 +150,38 @@
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
-      
+
+        <!-- Adventure API for &#RGB display -->
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.23.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-legacy</artifactId>
+            <version>4.23.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-gson</artifactId>
+            <version>4.23.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-platform-bukkit</artifactId>
+            <version>4.4.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>examination-api</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+
         <!-- PircBotX -->
         <dependency>
             <groupId>org.pircbotx</groupId>
@@ -493,6 +528,7 @@
                                     <include>org.apache.commons</include>
                                     <include>com.google.common</include>
                                     <include>com.google.guava</include>
+                                    <include>net.kyori:*</include>
                                     <include>commons-io</include>
                                 </includes>
                             </artifactSet>

--- a/src/main/java/com/cnaude/purpleirc/GameListeners/IRCMessageListener.java
+++ b/src/main/java/com/cnaude/purpleirc/GameListeners/IRCMessageListener.java
@@ -67,11 +67,12 @@ public class IRCMessageListener implements Listener {
             plugin.messageQueue.add(new Message(fixedMessage, permission));
         } else {
             plugin.logDebug("Broadcast Players [" + permission + "]: " + fixedMessage);
-            for (Player p : plugin.getServer().getOnlinePlayers()) {
-                if (p.hasPermission(permission)) {
-                    p.sendMessage(fixedMessage);
-                }
-            }
+//            for (Player p : plugin.getServer().getOnlinePlayers()) {
+//                if (p.hasPermission(permission)) {
+//                    p.sendMessage(fixedMessage);
+//                }
+//            }
+            plugin.sendMessageToPlayers(fixedMessage, permission);
         }
         
     }

--- a/src/main/java/com/cnaude/purpleirc/MessageQueueWatcher.java
+++ b/src/main/java/com/cnaude/purpleirc/MessageQueueWatcher.java
@@ -51,7 +51,8 @@ public class MessageQueueWatcher {
     private void queueAndSend() {
         Message message = queue.poll();
         if (message != null) {
-            plugin.getServer().broadcast(message.message, message.permission);
+//            plugin.getServer().broadcast(message.message, message.permission);
+            plugin.broadcast(message.message, message.permission);
         }
     }
 

--- a/src/main/java/com/cnaude/purpleirc/PurpleBot.java
+++ b/src/main/java/com/cnaude/purpleirc/PurpleBot.java
@@ -2901,8 +2901,11 @@ public final class PurpleBot {
         if (isMessageEnabled(channelName, TemplateName.IRC_CONSOLE_CHAT)) {
             String tmpl = plugin.getMessageTemplate(botNick, channelName, TemplateName.IRC_CONSOLE_CHAT);
             plugin.logDebug("broadcastChat [Console]: " + tmpl);
-            plugin.getServer().getConsoleSender().sendMessage(plugin.tokenizer.ircChatToGameTokenizer(
-                    this, user, channel, plugin.getMessageTemplate(botNick, channelName, TemplateName.IRC_CONSOLE_CHAT), message));
+//            plugin.getServer().getConsoleSender().sendMessage(plugin.tokenizer.ircChatToGameTokenizer(
+//                    this, user, channel, plugin.getMessageTemplate(botNick, channelName, TemplateName.IRC_CONSOLE_CHAT), message));
+            plugin.sendMessageToConsole(plugin.tokenizer.ircChatToGameTokenizer(
+                    this, user, channel, plugin.getMessageTemplate(botNick, channelName, TemplateName.IRC_CONSOLE_CHAT), message)
+            );
             messageSent = true;
         }
 


### PR DESCRIPTION
You can now use formater like "&#1a2b3c" to display RGB colors on the origin Spigot server. Enable RGB for non-Paper servers.

This is implemented with the Kyori's Chat Component (https://docs.advntr.dev/text.html). It is also backward compatible with older version.